### PR TITLE
google_places_service_Rspec

### DIFF
--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -1,19 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe SearchesController, type: :controller do
-
-  describe "GET #index" do
-    it "returns http success" do
-      get :index
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET #search" do
-    it "returns http success" do
-      get :search
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -1,12 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe StaticPagesController, type: :controller do
-
-  describe "GET #view" do
-    it "returns http success" do
-      get :view
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end

--- a/spec/services/google_places_service_spec.rb
+++ b/spec/services/google_places_service_spec.rb
@@ -1,0 +1,47 @@
+
+require "rails_helper"
+
+RSpec.describe GooglePlacesService, type: :service do
+    let(:service) { described_class.new("test_api_key") } 
+    let(:place_id) { "ChIJN1t_tDeuEmsRUsoyG83frY4" } 
+    let(:photo_reference) { "CmRaAAAAE3q4oh5qp5uexK-0-T1sgbpJvMr9Kf8T" }
+
+    describe "#search_places" do
+        it "適切なエンドポイントに適切なクエリでリクエストを送信していることを確認する" do
+            query = { input: "東京タワー", key: "test_api_key" }
+            stub_request(:get, "https://maps.googleapis.com/maps/api/place/findplacefromtext/json")
+                .with(query: hash_including(query))
+                .to_return(status: 200, body: { status: "OK" }.to_json)
+
+            service.search_places("東京タワー")
+
+            expect(WebMock).to have_requested(:get, "https://maps.googleapis.com/maps/api/place/findplacefromtext/json")
+                .with(query: hash_including(query))
+        end
+    end
+
+    describe "#get_place_details" do
+        it "適切なエンドポイントに適切なクエリでリクエストを送信していることを確認する" do
+            query = { place_id: place_id, key: "test_api_key" }
+            stub_request(:get, "https://maps.googleapis.com/maps/api/place/details/json")
+                .with(query: hash_including(query))
+                .to_return(status: 200, body: { result: {} }.to_json)
+
+            service.get_place_details(place_id)
+
+            expect(WebMock).to have_requested(:get, "https://maps.googleapis.com/maps/api/place/details/json")
+                .with(query: hash_including(query))
+        end
+    end
+
+    describe "#get_photo" do
+        it "正しい写真のURLへのリクエストを送信していることを確認する" do
+            photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=#{photo_reference}&key=test_api_key"
+            stub_request(:get, photo_url)
+                .to_return(status: 200, body: "", headers: {})
+
+            expect(service.get_photo(photo_reference)).to be_truthy
+            expect(WebMock).to have_requested(:get, photo_url)
+        end
+    end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
# 概要

google_places_service_Rspec

## 実装内容

- [x] Rspecにてgoogle_places_serviceのテストコード記述
- [x] webmockのgem追加

closes #12 

[![Image from Gyazo](https://i.gyazo.com/2c4f72efc15306ea989bd3957a2d55bf.png)](https://gyazo.com/2c4f72efc15306ea989bd3957a2d55bf)

https://www.notion.so/0dbd173a13064851b3f3a0ac10aa5864?v=aca4b88320f044d389c97fe0eb9fe340&p=3254b87f1feb435fa8f57a79b2ab69ab&pm=s