### PR TITLE
chatgpt_service_Rspec

### DIFF
--- a/spec/services/chatgpt_service_service_spec.rb
+++ b/spec/services/chatgpt_service_service_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChatgptService, type: :service do
+    let(:api_key) { "test_api_key" }
+    let(:service) { described_class.new(api_key) }
+    let(:messages) { [{ role: "user", content: "Hello" }] }
+
+    before do
+        ENV["OPEN_AI_API_KEY"] = api_key
+        stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .with(
+            headers: {
+                "Authorization" => "Bearer #{api_key}",
+                "Content-Type" => "application/json"
+            },
+            body: {
+                model: "gpt-4-turbo-preview",
+                messages: messages
+            }.to_json
+        )
+        .to_return(status: 200, body: { choices: [{ message: { content: "Hello, how can I help you?" } }] }.to_json)
+    end
+
+    describe "APIキーを正しく取得できているか" do
+        it "APIキーが環境変数から正しく設定されていること" do
+            expect(service.instance_variable_get(:@api_key)).to eq(api_key)
+        end
+    end
+
+    describe "正しいエンドポイントのアクセスしているか" do
+        it "適切なエンドポイントにリクエストを送信していること" do
+            service.create_chat_completion(messages)
+            expect(a_request(:post, "https://api.openai.com/v1/chat/completions")).to have_been_made.once
+        end
+    end
+
+    describe "APIからのエラーが適切にハンドルされるか" do
+        it "APIからのエラーレスポンスを適切に処理できること" do
+            stub_request(:post, "https://api.openai.com/v1/chat/completions")
+                .to_return(status: 500, body: { error: "Internal Server Error" }.to_json)
+
+            expect { service.create_chat_completion(messages) }
+                .to_not raise_error
+        end
+    end
+end


### PR DESCRIPTION
# 概要

chatgpt_service_service_Rspec

## 実装内容

- [x]  Rspecにてのテストコード記述

closes #16 

[![Image from Gyazo](https://i.gyazo.com/8d7424d3b7d35728485c1063a53089ef.png)](https://gyazo.com/8d7424d3b7d35728485c1063a53089ef)

https://www.notion.so/0dbd173a13064851b3f3a0ac10aa5864?v=aca4b88320f044d389c97fe0eb9fe340&p=0c82080b08c24c10904ccb96555319dd&pm=s