### PR TITLE
google_directions_service_Rspec

### DIFF
--- a/spec/controllers/google_directions_service_spec.rb
+++ b/spec/controllers/google_directions_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GoogleDirectionsService, type: :service do
+    let(:api_key) { "test_api_key" } 
+    let(:service) { described_class.new(api_key) }
+    let(:origin) { "Tokyo Station" }
+    let(:destination) { "Yokohama Station" } 
+    let(:departure_time) { "now" }
+
+    describe "#get_directions" do
+        it "適切なエンドポイントに適切なクエリパラメータでリクエストを送信していることを確認する" do
+            stub_request(:get, "https://maps.googleapis.com/maps/api/directions/json")
+                .with(query: {
+                    origin: origin,
+                    destination: destination,
+                    mode: "driving",
+                    departure_time: departure_time,
+                    key: api_key
+                })
+                .to_return(status: 200, body: { routes: [] }.to_json)
+
+                response = service.get_directions(origin, destination, departure_time)
+
+                expect(WebMock).to have_requested(:get, "https://maps.googleapis.com/maps/api/directions/json")
+                .with(query: {
+                    origin: origin,
+                    destination: destination,
+                    mode: "driving",
+                    departure_time: departure_time,
+                    key: api_key
+                })
+                expect(response).to be_a(HTTParty::Response)
+                expect(response.parsed_response).to include("routes")
+        end
+    end
+end


### PR DESCRIPTION
# 概要

google_directions_service_Rspec

## 実装内容

- [x]  Rspecにてのテストコード記述

closes #26 

[![Image from Gyazo](https://i.gyazo.com/dedde7d746f995554268074db6b213d7.png)](https://gyazo.com/dedde7d746f995554268074db6b213d7)

https://www.notion.so/0dbd173a13064851b3f3a0ac10aa5864?v=aca4b88320f044d389c97fe0eb9fe340&p=61b7216b3fd94aa4a33caa2f792c3511&pm=s